### PR TITLE
Collapse refactor

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,8 +1,8 @@
-DEBUG=False
+DEBUG=True
 ALLOWED_HOSTS=localhost
 SECRET_KEY="a=9u^+k-0k7gr^do_8up%zjld!ze1ur(7(+r2m%bx&wlnd2ywb"
 DATABASE_URL=postgres://localhost:5432/salt
-GITHUB_TEAM_ID=
-GITHUB_TEAM_KEY=
-GITHUB_TEAM_SECRET=
+GITHUB_TEAM_ID=''
+GITHUB_TEAM_KEY=''
+GITHUB_TEAM_SECRET=''
 SENTRY_DSN=

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -5,38 +5,36 @@ import 'bootstrap';
 class App {
   constructor($) {
     this.$ = $;
-    this.toggleButtonState();
-    this.navigateOnFilter();
+    this.$('a[data-toggle="collapse-optimized"]').on('click', this.toggleResultState.bind(this));
+    this.$('#minion-filter').on('input', this.navigateOnFilter.bind(this));
+  }
+  
+  toggleResultState(evt) {
+    const $this = this.$(evt.currentTarget);
+    const klass = $this.data('button-toggle-class');
+    const shownClass = `btn-${klass}`;
+    const hiddenClass = `btn-outline-${klass}`;
+    // blur removes an ugly boostrap halo on :focus
+    if ($this.hasClass(hiddenClass)) {
+      $this.removeClass(hiddenClass).addClass(shownClass);
+      this.$($this.data('target')).addClass(`state-${$this.data('target-status')}`);
+    } else {
+      $this.removeClass(shownClass).addClass(hiddenClass);
+      this.$($this.data('target')).removeClass(`state-${$this.data('target-status')}`);
+    }
+    evt.preventDefault();
   }
 
-  toggleButtonState() {
-    const $ = this.$;
-    $('a[data-button-toggle-class]').on('click', function() {
-      const $this = $(this);
-      const klass = $(this).data('button-toggle-class');
-      const shownClass = `btn-${klass}`;
-      const hiddenClass = `btn-outline-${klass}`;
-      // blur removes an ugly boostrap halo on :focus
-      if ($this.hasClass(hiddenClass)) {
-        $this.removeClass(hiddenClass).addClass(shownClass).blur();
-      } else {
-        $this.removeClass(shownClass).addClass(hiddenClass).blur();
-      }
-    });
-  }
-
-  navigateOnFilter() {
-    const $ = this.$;
-    $('#minion-filter').on('input', function() {
-      const val = this.value;
-      const datalist = document.getElementById(this.getAttribute('list'));
-      const inDatalist = $(datalist).find('option').filter(function() {
-        return this.value.toLowerCase() === val.toLowerCase();
-      }).length;
-      if (inDatalist) {
-        $(this).parents('form').submit();
-      }
-    });
+  navigateOnFilter(evt) {
+    const val = this.value;
+    const datalist = document.getElementById(this.getAttribute('list'));
+    const inDatalist = this.$(datalist).find('option').filter(function() {
+      return this.value.toLowerCase() === val.toLowerCase();
+    }).length;
+    if (inDatalist) {
+      this.$(evt.currentTarget).parents('form').submit();
+    }
+    evt.preventDefault();
   }
 }
 

--- a/client/scss/app.scss
+++ b/client/scss/app.scss
@@ -1,1 +1,24 @@
 @import "../node_modules/bootstrap/scss/bootstrap.scss";
+
+.state-list-container {
+  &.state-failed {
+    [data-state-status="failed"] {
+      display: block;
+    }
+  }
+  &.state-unchanged {
+    [data-state-status="unchanged"] {
+      display: block;
+    }
+  }
+  &.state-changed {
+    [data-state-status="changed"] {
+      display: block;
+    }
+  }
+  &.state-requisite-failed {
+    [data-state-status="requisite-failed"] {
+      display: block;
+    }
+  }
+}

--- a/saltdash/dash/templates/dash/_result_card.html
+++ b/saltdash/dash/templates/dash/_result_card.html
@@ -20,37 +20,41 @@
     {% if result.is_state %}
       {% if result.states_failed > 0 %}
         <a href="#"
-           data-toggle="collapse"
+           data-toggle="collapse-optimized"
            data-button-toggle-class="danger"
-           data-target='div#result-{{ result.pk }} [data-state-status="failed"]'
+           data-target='div#result-{{ result.pk }}'
+           data-target-status='failed'
            class="btn btn-sm btn-danger">{{ result.states_failed }} failed</a>
       {% endif %}
 
       {% if result.states_failed_requisite > 0 %}
         <a href="#"
-           data-toggle="collapse"
+           data-toggle="collapse-optimized"
            data-button-toggle-class="warning"
-           data-target='div#result-{{ result.pk }} [data-state-status="requisite-failed"]'
+           data-target='div#result-{{ result.pk }}'
+           data-target-status="requisite-failed"
            class="btn btn-sm btn-outline-warning">{{ result.states_failed_requisite }} failed req</a>
       {% endif %}
 
       {% if result.states_changed > 0 %}
         <a href="#"
-           data-toggle="collapse"
+           data-toggle="collapse-optimized"
            data-button-toggle-class="success"
-           data-target='div#result-{{ result.pk }} [data-state-status="changed"]'
+           data-target='div#result-{{ result.pk }}'
+           data-target-status="changed"
            class="btn btn-sm btn{% if collapsed %}-outline{% endif %}-success">{{ result.states_changed }} changed</a>
       {% endif %}
 
       {% if result.states_unchanged > 0 %}
         <a href="#"
-           data-toggle="collapse"
+           data-toggle="collapse-optimized"
            data-button-toggle-class="secondary"
-           data-target='div#result-{{ result.pk }} [data-state-status="unchanged"]'
+           data-target='div#result-{{ result.pk }}'
+           data-target-status='unchanged'
            class="btn btn-sm btn-outline-secondary">{{ result.states_unchanged }} unchanged</a>
       {% endif %}
 
-      <div id="result-{{ result.pk }}">
+      <div id="result-{{ result.pk }}" class="state-list-container state-failed">
         {% include "dash/_results/"|add:result.result_type|add:".html" with result=result %}
       </div>
     {% else %}
@@ -58,12 +62,12 @@
       {# not state output, just text/json #}
       {% if collapsed %}
       <a href="#result-{{ result.pk }}"
-         data-toggle="collapse"
-         class="text-muted{% if result.success %}  collapsed{% endif %}">Show/hide results</a>
+         data-toggle="collapse-optimized"
+         class="text-muted{% if result.success %} collapsed{% endif %}">Show/hide results</a>
       {% endif %}
       {% if result.return_val %}
         <div id="result-{{ result.pk }}"
-             class="collapse {% if not collapsed or not result.success %}show{% endif %}">
+             class="collapse-optimized {% if not collapsed or not result.success %}show{% endif %}">
           {% include "dash/_results/"|add:result.result_type|add:".html" with result=result %}
         </div>
       {% endif %}

--- a/saltdash/dash/templates/dash/_result_card.html
+++ b/saltdash/dash/templates/dash/_result_card.html
@@ -62,12 +62,12 @@
       {# not state output, just text/json #}
       {% if collapsed %}
       <a href="#result-{{ result.pk }}"
-         data-toggle="collapse-optimized"
+         data-toggle="collapse"
          class="text-muted{% if result.success %} collapsed{% endif %}">Show/hide results</a>
       {% endif %}
       {% if result.return_val %}
         <div id="result-{{ result.pk }}"
-             class="collapse-optimized {% if not collapsed or not result.success %}show{% endif %}">
+             class="collapse {% if not collapsed or not result.success %}show{% endif %}">
           {% include "dash/_results/"|add:result.result_type|add:".html" with result=result %}
         </div>
       {% endif %}

--- a/saltdash/dash/templates/dash/_results/state.html
+++ b/saltdash/dash/templates/dash/_results/state.html
@@ -2,7 +2,7 @@
 <ul class="list-unstyled mt-2">
   {% for state in result.states %}
     <li data-state-status="{{ state.status }}"
-        class="collapse {% if state.status == 'failed' or state.status == 'changed' and not collapsed %}show{% endif %}">
+        class="collapse">
       <small class="text-muted float-right">{{ state.duration }}ms</small>
       <h5>
         <a href="#state-{{ result.pk }}-{{ state.order }}"

--- a/saltdash/settings.py
+++ b/saltdash/settings.py
@@ -181,7 +181,7 @@ log = logging.getLogger(__name__)
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = '/dist/'
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, os.pardir, 'client', 'dist')
 ]


### PR DESCRIPTION
Ended up getting rid of the bootstrap collapse, the way it was structured (collapsing individual items) was inefficient, so I changed it to be CSS based.
If the result list was grouped by state, and we were collapsing the containers instead of individual items, I think bootstrap would be good enough.
I didn't add css transitions, but it can be done if that is necessary.